### PR TITLE
Add CT_ARGS env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ djenriquez/ngicon
 ## Environment Variables
 * CONSUL_ADDRESS: The address of Consul. It is recommended to point Ngicon at the local Consul service. Defaults to `localhost`
 * CONSUL_PORT: The port to access Consul. Defaults to `8500`
+* CT_ARGS: Additional arguments to pass into consul-template CLI, ex: `-dedup`.
 
 ## Templating
 Templates to be parsed should be mounted to `/etc/consul-templates/` and end in `.tmpl.go`. Ngicon will take the file, strip off the `.tmpl.go` and place the new file in `/etc/nginx/conf.d/`.

--- a/src/services/consul-template.service
+++ b/src/services/consul-template.service
@@ -4,6 +4,10 @@ source /etc/envvars
 : ${LOG_LEVEL:="warn"}
 COMMAND="consul-template -consul-addr=$CONSUL_ADDRESS:$CONSUL_PORT"
 
+if [ -v $CT_ARGS ]; then 
+  COMMAND+=" $CT_ARGS"
+fi
+
 cd /etc/consul-templates/
 for TEMPLATE in *.tmpl.go;
 do


### PR DESCRIPTION
Allows users to pass in other arguments into Consul-Template via `CT_ARGS` env var.