### PR TITLE
StatsD Health Check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ ADD src/crontab /etc/crontab
 
 # Start commands
 ADD start.sh /usr/sbin/start.sh
+ADD nginx-check /usr/sbin/nginx-check
 
 ENV CONSUL_ADDRESS localhost
 ENV CONSUL_PORT 8500

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,11 @@ ADD src/logrotate/ /etc/logrotate.d/
 # Add crontab
 ADD src/crontab /etc/crontab
 
+# Add nginx-check
+ADD src/nginx-check /usr/sbin/nginx-check
+
 # Start commands
 ADD start.sh /usr/sbin/start.sh
-ADD nginx-check /usr/sbin/nginx-check
 
 ENV CONSUL_ADDRESS localhost
 ENV CONSUL_PORT 8500

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ djenriquez/ngicon
 * CONSUL_ADDRESS: The address of Consul. It is recommended to point Ngicon at the local Consul service. Defaults to `localhost`
 * CONSUL_PORT: The port to access Consul. Defaults to `8500`
 * CT_ARGS: Additional arguments to pass into consul-template CLI, ex: `-dedup`.
+* APP: Optional identifier used for the StatsD health check as a dimension.
 
 ## Templating
 Templates to be parsed should be mounted to `/etc/consul-templates/` and end in `.tmpl.go`. Ngicon will take the file, strip off the `.tmpl.go` and place the new file in `/etc/nginx/conf.d/`.
+
+## Health Checks
+NGICON runs a check against the `nginx -t` command against the configuration. This test will run every minute through cron AND everytime consul-template attempts to process a change to the config.
+
+Results of the test are sent to localhost:8125/udp as the metric `nginx.conf.ok`, with an optional dimension of `app`, which reads in the environment variable `$APP`. This assumes an optional StatsD listener exists. The test returns:
+|Result | Status |
+|---:|---|
+| 0 | Good |
+| 1 | Unknown |
+| 2 | Bad |

--- a/src/crontab
+++ b/src/crontab
@@ -13,3 +13,6 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 47 6	* * 7	root	test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.weekly )
 52 6	1 * *	root	test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.monthly )
 #
+
+# Forces the nginx-check to happen atleast once a minute
+* * * * * root nginx-check

--- a/src/nginx-check
+++ b/src/nginx-check
@@ -1,0 +1,15 @@
+#!/bin/bash
+source /etc/envvars
+NGINX_TEST=$(nginx -t 2>&1)
+
+echo $NGINX_TEST > /etc/nginx/status.txt
+
+if [[ $NGINX_TEST == *"failed"* ]]
+then
+  echo "ngicon.conf.[app=$APP]ok:2|g" > /dev/udp/localhost/8125
+elif [[ $NGINX_TEST == *"success"* ]]
+then
+  echo "ngicon.conf.[app=$APP]ok:0|g" > /dev/udp/localhost/8125
+else
+  echo "ngicon.conf.[app=$APP]ok:1|g" > /dev/udp/localhost/8125
+fi

--- a/src/services/consul-template.service
+++ b/src/services/consul-template.service
@@ -13,11 +13,11 @@ for TEMPLATE in *.tmpl.go;
 do
   FILE_NAME=`echo $TEMPLATE | sed -e 's/\(.*\)\(.tmpl.go\)/\1/'`
   if [[ "$FILE_NAME" = "nginx.conf" ]]; then
-    COMMAND+=" -template \"/etc/consul-templates/$TEMPLATE:/etc/nginx/$FILE_NAME:sv hup nginx\""
+    COMMAND+=" -template \"/etc/consul-templates/$TEMPLATE:/etc/nginx/$FILE_NAME:nginx-check && sv hup nginx\""
   elif [[ "$FILE_NAME" = "stream.conf" ]]; then
-    COMMAND+=" -template \"/etc/consul-templates/$TEMPLATE:/etc/nginx/stream.d/$FILE_NAME:sv hup nginx\""
+    COMMAND+=" -template \"/etc/consul-templates/$TEMPLATE:/etc/nginx/stream.d/$FILE_NAME:nginx-check && sv hup nginx\""
   else
-    COMMAND+=" -template \"/etc/consul-templates/$TEMPLATE:/etc/nginx/conf.d/$FILE_NAME:sv hup nginx\""
+    COMMAND+=" -template \"/etc/consul-templates/$TEMPLATE:/etc/nginx/conf.d/$FILE_NAME:nginx-check && sv hup nginx\""
   fi
 done
 


### PR DESCRIPTION
# Summary
This PR creates a health check statsd gauge for the NGINX configuration. On every update, or once a minute, ngicon will check the status of the NGINX configuration and update the status to a statsd gauge metric `ngicon.conf.ok` with an optional dimension of `app`. It assumes a statsd listener running on the default udp/8215 port on localhost.

This can be used to create a monitor/alert for the status of the NGINX configuration incase the template processed a configuration that is bad.